### PR TITLE
Updated to use aref object and write-Warning

### DIFF
--- a/disable.ps1
+++ b/disable.ps1
@@ -2,6 +2,8 @@ $config = ConvertFrom-Json $configuration
 
 $BaseUri = $config.BaseUri
 $Token = $config.Token
+$RelationNumber = $config.RelationNumber
+$updateUserId = $config.updateUserId
 $getConnector = "T4E_HelloID_Users"
 $updateConnector = "knUser"
 
@@ -16,7 +18,8 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.ExternalId; # Profit Employee Nummer
+$filterfieldid = "Gebruiker"
+$filtervalue = $aRef.Gebruiker; # Has to match the AFAS value of the specified filter field ($filterfieldid)
 
 $currentDate = (Get-Date).ToString("dd/MM/yyyy hh:mm:ss")
 
@@ -24,19 +27,31 @@ try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
 
     if($getResponse.rows.Count -eq 1 -and (![string]::IsNullOrEmpty($getResponse.rows.Gebruiker))){
-        # Change mapping here
+        # Retrieve current account data for properties to be updated
+        $previousAccount = [PSCustomObject]@{
+            'KnUser' = @{
+                'Element' = @{
+                    '@UsId' = $getResponse.rows.Gebruiker;
+                    'Fields' = @{
+                        # InSite
+                        'InSi' = $getResponse.rows.InSite;
+                    }
+                }
+            }
+        }
+       
+        # Map the properties to update
         $account = [PSCustomObject]@{
             'KnUser' = @{
                 'Element' = @{
                     '@UsId' = $getResponse.rows.Gebruiker;
                     'Fields' = @{
                         # Mutatie code
-                        'MtCd' = 2;
+                        'MtCd' = 6;
                         # Omschrijving
                         "Nm" = "Disabled by HelloID Provisioning on $currentDate";
 
@@ -48,30 +63,45 @@ try{
                     }
                 }
             }
-        }
+        }      
+
+        # Set aRef object for use in futher actions
+        $aRef = [PSCustomObject]@{
+            Gebruiker = $($account.knUser.Values.'@UsId')
+        }  
 
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
             $putUri = $BaseUri + "/connectors/" + $updateConnector
 
-            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
+            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing -ErrorAction Stop
         }
-
+        
         $auditLogs.Add([PSCustomObject]@{
             Action = "DisableAccount"
-            Message = "Disabled account with Id $($aRef)"
+            Message = "Disabled account with Id $($aRef.Gebruiker)"
             IsError = $false;
         });
 
-        $success = $true;            
+        $success = $true;          
     }
+    else {
+        $auditLogs.Add([PSCustomObject]@{
+            Action = "DeleteAccount"
+            Message = "No profit user found for person $filtervalue";
+            IsError = $false;
+        });        
+
+        $success = $true;         
+        Write-Warning "No profit user found for person $filtervalue";
+    }    
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "DisableAccount"
-        Message = "Error disabling account with Id $($aRef): $($_)"
+        Message = "Error disabling account with Id $($aRef.Gebruiker): $($_)"
         IsError = $True
     });
-	Write-Error $_;    
+    Write-Warning $_;
 }
 
 # Send results
@@ -80,5 +110,11 @@ $result = [PSCustomObject]@{
 	AccountReference= $aRef;
 	AuditLogs = $auditLogs;
     Account = $account;
+    PreviousAccount = $previousAccount;    
+
+    # Optionally return data for use in other systems
+    ExportData = [PSCustomObject]@{
+        Gebruiker               = $aRef.Gebruiker
+    };    
 };
 Write-Output $result | ConvertTo-Json -Depth 10;

--- a/enable.ps1
+++ b/enable.ps1
@@ -2,6 +2,8 @@ $config = ConvertFrom-Json $configuration
 
 $BaseUri = $config.BaseUri
 $Token = $config.Token
+$RelationNumber = $config.RelationNumber
+$updateUserId = $config.updateUserId
 $getConnector = "T4E_HelloID_Users"
 $updateConnector = "knUser"
 
@@ -16,7 +18,8 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.ExternalId; # Profit Employee Nummer
+$filterfieldid = "Gebruiker"
+$filtervalue = $aRef.Gebruiker; # Has to match the AFAS value of the specified filter field ($filterfieldid)
 
 $currentDate = (Get-Date).ToString("dd/MM/yyyy hh:mm:ss")
 
@@ -24,12 +27,24 @@ try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
 
     if($getResponse.rows.Count -eq 1 -and (![string]::IsNullOrEmpty($getResponse.rows.Gebruiker))){
-        # Change mapping here
+        # Retrieve current account data for properties to be updated
+        $previousAccount = [PSCustomObject]@{
+            'KnUser' = @{
+                'Element' = @{
+                    '@UsId' = $getResponse.rows.Gebruiker;
+                    'Fields' = @{
+                        # InSite
+                        'InSi' = $getResponse.rows.InSite;
+                    }
+                }
+            }
+        }
+       
+        # Map the properties to update
         $account = [PSCustomObject]@{
             'KnUser' = @{
                 'Element' = @{
@@ -48,30 +63,45 @@ try{
                     }
                 }
             }
-        }
+        }      
+
+        # Set aRef object for use in futher actions
+        $aRef = [PSCustomObject]@{
+            Gebruiker = $($account.knUser.Values.'@UsId')
+        }  
 
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
             $putUri = $BaseUri + "/connectors/" + $updateConnector
 
-            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
+            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing -ErrorAction Stop
         }
-
+        
         $auditLogs.Add([PSCustomObject]@{
             Action = "EnableAccount"
-            Message = "Enabled account with Id $($aRef)"
+            Message = "Enabled account with Id $($aRef.Gebruiker)"
             IsError = $false;
         });
 
-        $success = $true;    
+        $success = $true;          
     }
+    else {
+        $auditLogs.Add([PSCustomObject]@{
+            Action = "DeleteAccount"
+            Message = "No profit user found for person $filtervalue";
+            IsError = $false;
+        });        
+
+        $success = $true;         
+        Write-Warning "No profit user found for person $filtervalue";
+    }        
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "EnableAccount"
-        Message = "Error enabling account with Id $($aRef): $($_)"
+        Message = "Error enabling account with Id $($aRef.Gebruiker): $($_)"
         IsError = $True
     });
-	Write-Error $_;
+    Write-Warning $_;
 }
 
 # Send results
@@ -80,5 +110,11 @@ $result = [PSCustomObject]@{
 	AccountReference= $aRef;
 	AuditLogs = $auditLogs;
     Account = $account;
+    PreviousAccount = $previousAccount;    
+
+    # Optionally return data for use in other systems
+    ExportData = [PSCustomObject]@{
+        Gebruiker               = $aRef.Gebruiker
+    };    
 };
 Write-Output $result | ConvertTo-Json -Depth 10;

--- a/update.ps1
+++ b/update.ps1
@@ -2,13 +2,13 @@ $config = ConvertFrom-Json $configuration
 
 $BaseUri = $config.BaseUri
 $Token = $config.Token
+$RelationNumber = $config.RelationNumber
+$updateUserId = $config.updateUserId
 $getConnector = "T4E_HelloID_Users"
 $updateConnector = "knUser"
 
 #Initialize default properties
 $p = $person | ConvertFrom-Json;
-$pp = $previousPerson | ConvertFrom-Json
-$pd = $personDifferences | ConvertFrom-Json
 $m = $manager | ConvertFrom-Json;
 $aRef = $accountReference | ConvertFrom-Json;
 $mRef = $managerAccountReference | ConvertFrom-Json;
@@ -18,18 +18,22 @@ $auditLogs = New-Object Collections.Generic.List[PSCustomObject];
 # Set TLS to accept TLS, TLS 1.1 and TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12
 
-$personId = $p.ExternalId; # Profit Employee Nummer
-$emailaddress = $p.Accounts.AzureADSchoulens.userPrincipalName;
-$userPrincipalName = $p.Accounts.AzureADSchoulens.userPrincipalName;
+$filterfieldid = "Gebruiker"
+$filtervalue = $aRef.Gebruiker; # Has to match the AFAS value of the specified filter field ($filterfieldid)
+$emailaddress = $p.Accounts.MicrosoftActiveDirectory.mail;
+$userPrincipalName = $p.Accounts.MicrosoftActiveDirectory.userPrincipalName;
+$userId = $RelationNumber + "." + $p.Custom.employeeNumber;
 
 $currentDate = (Get-Date).ToString("dd/MM/yyyy hh:mm:ss")
+
+$EmAdUpdated = $false
+$UpnUpdated = $false
 
 try{
     $encodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Token))
     $authValue = "AfasToken $encodedToken"
     $Headers = @{ Authorization = $authValue }
-
-    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=Persoonsnummer&filtervalues=$personId&operatortypes=1"
+    $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
     $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
 
     if($getResponse.rows.Count -eq 1 -and (![string]::IsNullOrEmpty($getResponse.rows.Gebruiker))){
@@ -48,6 +52,43 @@ try{
             }
         }
         
+        if($updateUserId -eq $true){
+            # If User ID doesn't match naming convention, update this
+            if($getResponse.rows.Gebruiker -ne $userId){
+                $account = [PSCustomObject]@{
+                    'KnUser' = @{
+                        'Element' = @{
+                            '@UsId' = $getResponse.rows.Gebruiker;
+                            'Fields' = @{
+                                # Mutatie code
+                                'MtCd' = 4;
+                                # Omschrijving
+                                "Nm" = "Updated User ID by HelloID Provisioning on $currentDate";
+
+                                # Persoon code - Only specify this if you want to update the linked person - Make sure this has a value, otherwise the link will disappear
+                                # "BcCo" = $getResponse.rows.Persoonsnummer;  
+
+                                # Nieuwe gebruikerscode
+                                "UsIdNew" = $userId;    
+                            }
+                        }
+                    }
+                }
+
+                if(-Not($dryRun -eq $True)){
+                    $body = $account | ConvertTo-Json -Depth 10
+                    $putUri = $BaseUri + "/connectors/" + $updateConnector
+
+                    $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing -ErrorAction Stop
+                    Write-Verbose -Verbose "UserId [$($getResponse.rows.Gebruiker)] updated to [$userId]"
+                }
+		
+                # Get Person data to make sure we have the latest fields (after update of UserId)
+                $getUri = $BaseUri + "/connectors/" + $getConnector + "?filterfieldids=$filterfieldid&filtervalues=$filtervalue&operatortypes=1"
+                $getResponse = Invoke-RestMethod -Method Get -Uri $getUri -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
+            }
+        }
+       
         # Map the properties to update
         $account = [PSCustomObject]@{
             'KnUser' = @{
@@ -69,6 +110,8 @@ try{
             # UPN
             $account.'KnUser'.'Element'.'Fields' += @{'Upn' = $userPrincipalName}
             Write-Verbose -Verbose "Updating UPN '$($getResponse.rows.UPN)' with new value '$userPrincipalName'"
+            # Set variable to indicate update of Upn has occurred (for export data object)
+            $UpnUpdated = $true
         }
 
         # If '$emailAdddres' does not match current 'EmAd', add 'EmAd' to update body. AFAS will throw an error when trying to update this with the same value
@@ -76,30 +119,47 @@ try{
             # E-mail
             $account.'KnUser'.'Element'.'Fields' += @{'EmAd' = $emailaddress}
             Write-Verbose -Verbose "Updating BusinessEmailAddress '$($getResponse.rows.Email_werk_gebruiker)' with new value '$emailaddress'"
-        }        
+            # Set variable to indicate update of EmAd has occurred (for export data object)
+            $EmAdUpdated = $true
+        }                  
+
+        # Set aRef object for use in futher actions
+        $aRef = [PSCustomObject]@{
+            Gebruiker = $($account.knUser.Values.'@UsId')
+        }  
 
         if(-Not($dryRun -eq $True)){
             $body = $account | ConvertTo-Json -Depth 10
             $putUri = $BaseUri + "/connectors/" + $updateConnector
 
-            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing
+            $putResponse = Invoke-RestMethod -Method Put -Uri $putUri -Body $body -ContentType "application/json;charset=utf-8" -Headers $Headers -UseBasicParsing -ErrorAction Stop
         }
-
+        
         $auditLogs.Add([PSCustomObject]@{
             Action = "UpdateAccount"
-            Message = "Updated fields of account  with Id $($aRef)"
+            Message = "Updated fields of account with id $($aRef.Gebruiker)"
             IsError = $false;
         });
 
-        $success = $true;  
+        $success = $true;          
     }
+    else {
+        $auditLogs.Add([PSCustomObject]@{
+            Action = "DeleteAccount"
+            Message = "No profit user found for person $filtervalue";
+            IsError = $false;
+        });        
+
+        $success = $false;         
+        Write-Warning "No profit user found for person $filtervalue";
+    }    
 }catch{
     $auditLogs.Add([PSCustomObject]@{
         Action = "UpdateAccount"
-        Message = "Error updating fields of account with Id $($aRef): $($_)"
+        Message = "Error updating fields of account with Id $($aRef.Gebruiker): $($_)"
         IsError = $True
     });
-	Write-Error $_;
+    Write-Warning $_;
 }
 
 # Send results
@@ -108,13 +168,19 @@ $result = [PSCustomObject]@{
 	AccountReference= $aRef;
 	AuditLogs = $auditLogs;
     Account = $account;
-    PreviousAccount = $previousAccount;   
+    PreviousAccount = $previousAccount;    
 
     # Optionally return data for use in other systems
     ExportData = [PSCustomObject]@{
-        UserId                  = $($account.knUser.Values.'@UsId')
-        UPN                     = $($account.KnUser.Element.Fields.UPN)
-        BusinessEmailAddress    = $($account.KnUser.Element.Fields.EmAd)
-    };
+        Gebruiker               = $aRef.Gebruiker
+    };    
 };
+
+# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
+if($UpnUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
+}
+if($EmAdUpdated -eq $true){
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
+}
 Write-Output $result | ConvertTo-Json -Depth 10;


### PR DESCRIPTION
Updated to make use of the aRef object on every action where this is available (all actions except for the create action, since we create the aRef object in the create action.
This way the actions aren't dependent on data from other systems (source or target).

Also switched out the Write-Error for Write-Warning, since this can cause the audit log to not show the correct message.