### PR TITLE
changed update exportdata

### DIFF
--- a/create.ps1
+++ b/create.ps1
@@ -565,12 +565,12 @@ $result = [PSCustomObject]@{
 if ($UpnUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
 }else{
-    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.UPN) -Force
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $currentAccount.UPN -Force
 }
 if ($EmAdUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
 }else{
-    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.EmAd) -Force
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($currentAccount.Email_werk_gebruiker) -Force
 }
 
 

--- a/create.ps1
+++ b/create.ps1
@@ -561,11 +561,17 @@ $result = [PSCustomObject]@{
     }
 }
 
-# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
-if ($UpnUpdated -eq $true -or $action -eq 'Create') {
+#add the data to ExportData if it has actually been updated by helloID. otherwise update the values in HelloID with the current value
+if ($UpnUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.UPN) -Force
 }
-if ($EmAdUpdated -eq $true -or $action -eq 'Create') {
+if ($EmAdUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.EmAd) -Force
 }
+
+
 Write-Output $result | ConvertTo-Json -Depth 10

--- a/create.updateOnly.ps1
+++ b/create.updateOnly.ps1
@@ -510,11 +510,16 @@ $result = [PSCustomObject]@{
     }
 }
 
-# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
-if ($UpnUpdated -eq $true -or $action -eq 'Create') {
+#add the data to ExportData if it has actually been updated by helloID. otherwise update the values in HelloID with the current value
+if ($UpnUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.UPN) -Force
 }
-if ($EmAdUpdated -eq $true -or $action -eq 'Create') {
+if ($EmAdUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.EmAd) -Force
 }
+
 Write-Output $result | ConvertTo-Json -Depth 10

--- a/update.ps1
+++ b/update.ps1
@@ -317,11 +317,17 @@ $result = [PSCustomObject]@{
     }
 }
 
-# Only add the data to ExportData if it has actually been updated, since we want to store the data HelloID has sent
+#add the data to ExportData if it has actually been updated by helloID. otherwise update the values in HelloID with the current value
 if ($UpnUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.UPN) -Force
 }
 if ($EmAdUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
+}else{
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.EmAd) -Force
 }
+
+
 Write-Output $result | ConvertTo-Json -Depth 10

--- a/update.ps1
+++ b/update.ps1
@@ -321,12 +321,12 @@ $result = [PSCustomObject]@{
 if ($UpnUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($account.KnUser.Element.Fields.UPN) -Force
 }else{
-    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.UPN) -Force
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $currentAccount.UPN -Force
 }
 if ($EmAdUpdated -eq $true) {
     $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($account.KnUser.Element.Fields.EmAd) -Force
 }else{
-    $result.ExportData | Add-Member -MemberType NoteProperty -Name UPN -Value $($currentAccount.KnUser.Element.Fields.EmAd) -Force
+    $result.ExportData | Add-Member -MemberType NoteProperty -Name BusinessEmailAddress -Value $($currentAccount.Email_werk_gebruiker) -Force
 }
 
 


### PR DESCRIPTION
changed the way this connector handles to exportdata.
Exportdata will always filled based on account or currentAccount. so the data is always correct after an update or grant is triggered.