### PR TITLE
Encode aRef in get call

### DIFF
--- a/delete.ps1
+++ b/delete.ps1
@@ -166,7 +166,7 @@ try {
         $Headers.Add("IntegrationId", "45963_140664") # Fixed value - Tools4ever Partner Integration ID
 
         $splatWebRequest = @{
-            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$($correlationValue)&operatortypes=1"
+            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$([uri]::EscapeDataString($correlationValue))&operatortypes=1"
             Headers         = $headers
             Method          = 'GET'
             ContentType     = "application/json;charset=utf-8"

--- a/disable.ps1
+++ b/disable.ps1
@@ -163,7 +163,7 @@ try {
         $Headers.Add("IntegrationId", "45963_140664") # Fixed value - Tools4ever Partner Integration ID
 
         $splatWebRequest = @{
-            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$($correlationValue)&operatortypes=1"
+            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$([uri]::EscapeDataString($correlationValue))&operatortypes=1"
             Headers         = $headers
             Method          = 'GET'
             ContentType     = "application/json;charset=utf-8"

--- a/enable.ps1
+++ b/enable.ps1
@@ -158,7 +158,7 @@ try {
         $Headers.Add("IntegrationId", "45963_140664") # Fixed value - Tools4ever Partner Integration ID
 
         $splatWebRequest = @{
-            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$($correlationValue)&operatortypes=1"
+            Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$([uri]::EscapeDataString($correlationValue))&operatortypes=1"
             Headers         = $headers
             Method          = 'GET'
             ContentType     = "application/json;charset=utf-8"

--- a/update.ps1
+++ b/update.ps1
@@ -167,7 +167,7 @@ try {
             $Headers.Add("IntegrationId", "45963_140664") # Fixed value - Tools4ever Partner Integration ID
 
             $splatWebRequest = @{
-                Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$($correlationValue)&operatortypes=1"
+                Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$([uri]::EscapeDataString($correlationValue))&operatortypes=1"
                 Headers         = $headers
                 Method          = 'GET'
                 ContentType     = "application/json;charset=utf-8"


### PR DESCRIPTION
- fix for https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-AFAS-Profit-Users/issues/17

Changed 
`Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$($correlationValue)&operatortypes=1"`

In
 `Uri             = "$($actionContext.Configuration.BaseUri)/connectors/$($actionContext.Configuration.GetConnector)?filterfieldids=$($correlationProperty)&filtervalues=$([uri]::EscapeDataString($correlationValue))&operatortypes=1"`
